### PR TITLE
feat(models): add 5 positions, round-level range, shotsPerZone; facto…

### DIFF
--- a/src/components/SessionForm.jsx
+++ b/src/components/SessionForm.jsx
@@ -1,0 +1,265 @@
+// src/components/SessionForm.jsx
+import { useState } from "react";
+import {
+  TRAINING_TYPES,
+  DIRECTIONS,
+  ZONE_POSITIONS,
+  RANGE_TYPES,
+  emptyRound,
+  pretty,
+  normalizeInitial,
+} from "../lib/models";
+
+export default function SessionForm({ initial, onSubmit, onCancel }) {
+  const [model, setModel] = useState(normalizeInitial(initial));
+
+  const setField = (k, v) => setModel((m) => ({ ...m, [k]: v }));
+
+  const setZone = (rIdx, pos, patch) =>
+    setModel((m) => {
+      const rounds = [...m.rounds];
+      const zones = rounds[rIdx].zones.map((z) =>
+        z.position === pos ? { ...z, ...patch } : z
+      );
+      rounds[rIdx] = { ...rounds[rIdx], zones };
+      return { ...m, rounds };
+    });
+
+  const addRound = () =>
+    setModel((m) => ({
+      ...m,
+      rounds: [...m.rounds, emptyRound(m.rounds.length)],
+    }));
+
+  const removeRound = (i) =>
+    setModel((m) => ({
+      ...m,
+      rounds: m.rounds
+        .filter((_, idx) => idx !== i)
+        .map((r, idx) => ({ ...r, roundIndex: idx })),
+    }));
+
+  // Apply range to entire round (and mirror into zones)
+  const onChangeRoundRange = (i, newRange) =>
+    setModel((m) => {
+      const rounds = [...m.rounds];
+      const zones = rounds[i].zones.map((z) => ({ ...z, range: newRange }));
+      rounds[i] = { ...rounds[i], range: newRange, zones };
+      return { ...m, rounds };
+    });
+
+  // Apply attempts per zone (shots/round) to the whole round
+  const onChangeShotsPerZone = (i, val) =>
+    setModel((m) => {
+      const n = Number(val);
+      const rounds = [...m.rounds];
+      const zones = rounds[i].zones.map((z) => ({
+        ...z,
+        attempts: n,
+        made: Math.min(Number(z.made || 0), n), // clamp made ≤ attempts
+      }));
+      rounds[i] = { ...rounds[i], shotsPerZone: n, zones };
+      return { ...m, rounds };
+    });
+
+  const validate = () => {
+    const attempts = sum(model, "attempts");
+    const made = sum(model, "made");
+    if (made > attempts) return "Made cannot exceed attempts.";
+    if (!model.rounds.some((r) => Number(r.shotsPerZone || 0) > 0))
+      return "Add at least one shot.";
+    return null;
+  };
+
+  const submit = () => {
+    const err = validate();
+    if (err) return alert(err);
+
+    // Ensure zones mirror round.range and round.shotsPerZone before save
+    const normalizedRounds = model.rounds.map((r) => ({
+      ...r,
+      zones: r.zones.map((z) => ({
+        ...z,
+        range: r.range,
+        attempts: r.shotsPerZone,
+        made: Math.min(Number(z.made || 0), Number(r.shotsPerZone || 0)),
+      })),
+    }));
+
+    const attempts = normalizedRounds
+      .flatMap((r) => r.zones)
+      .reduce((a, z) => a + Number(z.attempts || 0), 0);
+    const made = normalizedRounds
+      .flatMap((r) => r.zones)
+      .reduce((a, z) => a + Number(z.made || 0), 0);
+
+    onSubmit({
+      ...model,
+      rounds: normalizedRounds,
+      totals: {
+        made,
+        attempts,
+        accuracy: attempts ? Math.round((made / attempts) * 100) : 0,
+      },
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Header row */}
+      <div className="grid gap-3 sm:grid-cols-3">
+        <input
+          type="date"
+          value={model.date}
+          onChange={(e) => setField("date", e.target.value)}
+          className="border rounded-xl p-2"
+        />
+        <select
+          value={model.type}
+          onChange={(e) => setField("type", e.target.value)}
+          className="border rounded-xl p-2"
+        >
+          {TRAINING_TYPES.map((t) => (
+            <option key={t}>{t}</option>
+          ))}
+        </select>
+        <input
+          placeholder="Notes"
+          value={model.notes}
+          onChange={(e) => setField("notes", e.target.value)}
+          className="border rounded-xl p-2"
+        />
+      </div>
+
+      {/* Rounds */}
+      {model.rounds.map((r, i) => (
+        <div key={i} className="border rounded-2xl p-3 space-y-3">
+          <div className="flex flex-wrap gap-3 items-center">
+            <span className="font-medium">Round {i + 1}</span>
+
+            {/* Direction */}
+            <select
+              value={r.direction}
+              onChange={(e) => {
+                const v = e.target.value;
+                setModel((m) => {
+                  const rounds = [...m.rounds];
+                  rounds[i] = { ...rounds[i], direction: v };
+                  return { ...m, rounds };
+                });
+              }}
+              className="border rounded-lg p-2"
+            >
+              {DIRECTIONS.map((d) => (
+                <option key={d}>{d}</option>
+              ))}
+            </select>
+
+            {/* Range for ALL zones */}
+            <select
+              value={r.range}
+              onChange={(e) => onChangeRoundRange(i, e.target.value)}
+              className="border rounded-lg p-2"
+              title="Shot range for all positions in this round"
+            >
+              {RANGE_TYPES.map((rt) => (
+                <option key={rt} value={rt}>
+                  {rt}
+                </option>
+              ))}
+            </select>
+
+            {/* shots/round (attempts per zone) */}
+            <select
+              value={r.shotsPerZone ?? 10}
+              onChange={(e) => onChangeShotsPerZone(i, e.target.value)}
+              className="border rounded-lg p-2"
+              title="Attempts per position for this round"
+            >
+              {[5, 10, 20].map((n) => (
+                <option key={n} value={n}>
+                  {n} shots/round
+                </option>
+              ))}
+            </select>
+
+            <button
+              type="button"
+              onClick={() => removeRound(i)}
+              className="ml-auto text-sm border rounded-lg px-2 py-1"
+            >
+              Remove
+            </button>
+          </div>
+
+          {/* Zone cards: 5 positions; Attempts are read-only and mirror shotsPerZone */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+            {ZONE_POSITIONS.map((pos) => {
+              const z =
+                r.zones.find((x) => x.position === pos) || {
+                  position: pos,
+                  range: r.range,
+                  made: 0,
+                  attempts: r.shotsPerZone ?? 10,
+                };
+              const attempts = Number(r.shotsPerZone ?? z.attempts ?? 0);
+              return (
+                <div key={pos} className="border rounded-xl p-3 space-y-2">
+                  <div className="text-sm font-medium">
+                    {pretty[pos]}{" "}
+                    <span className="text-xs text-gray-500">
+                      ({r.range} • {attempts})
+                    </span>
+                  </div>
+                  <div className="flex gap-2">
+                    {/* Made (editable) */}
+                    <input
+                      type="number"
+                      min="0"
+                      className="w-1/2 border rounded p-2"
+                      value={z.made ?? 0}
+                      onChange={(e) => {
+                        const n = Number(e.target.value);
+                        const clamped = Math.min(Math.max(0, n), attempts);
+                        setZone(i, pos, { made: clamped });
+                      }}
+                    />
+                    {/* Attempts (read-only) */}
+                    <input
+                      type="number"
+                      className="w-1/2 border rounded p-2 bg-gray-50"
+                      value={attempts}
+                      readOnly
+                      tabIndex={-1}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      <div className="flex gap-2">
+        <button type="button" onClick={addRound} className="border rounded-xl px-3 py-2">
+          + Add round
+        </button>
+        <div className="ml-auto flex gap-2">
+          <button type="button" onClick={onCancel} className="border rounded-xl px-3 py-2">
+            Cancel
+          </button>
+          <button type="button" onClick={submit} className="bg-black text-white rounded-xl px-4 py-2">
+            Save session
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** utils */
+function sum(model, key) {
+  return model.rounds
+    .flatMap((r) => r.zones)
+    .reduce((a, z) => a + (Number(z?.[key]) || 0), 0);
+}

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -1,0 +1,72 @@
+// Positions on the arc / floor
+export const ZONE_POSITIONS = [
+  "left_corner",
+  "left_wing",
+  "center",
+  "right_wing",
+  "right_corner",
+];
+
+// Shot range / type selector
+export const RANGE_TYPES = ["paint", "midrange", "3pt"];
+
+// Keep training types & directions as-is
+export const TRAINING_TYPES = ["spot", "catch_shoot", "off_dribble", "run_half"];
+export const DIRECTIONS = ["L→R", "R→L", "static"];
+
+// Helper to pretty print labels
+export const pretty = {
+  left_corner: "Left Corner",
+  left_wing: "Left Wing",
+  center: "Center",
+  right_wing: "Right Wing",
+  right_corner: "Right Corner",
+};
+
+// Round factory now includes range per zone (default to "3pt")
+export const emptyRound = (i = 0) => ({
+  roundIndex: i,
+  direction: "static",
+  range: "3pt",
+  shotsPerZone: 10, // NEW: attempts per position in this round (5/10/20)
+  zones: ZONE_POSITIONS.map((pos) => ({
+    position: pos,
+    range: "3pt",
+    made: 0,
+    attempts: 10,   // mirror shotsPerZone by default
+  })),
+});
+
+
+export const newSession = (userId) => ({
+  userId,
+  date: new Date().toISOString().slice(0, 10),
+  type: "spot",
+  notes: "",
+  rounds: [emptyRound(0)],
+  totals: { made: 0, attempts: 0, accuracy: 0 },
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+});
+
+export function normalizeInitial(s) {
+  const clone = JSON.parse(JSON.stringify(s));
+  clone.rounds = (clone.rounds || []).map((r, idx) => {
+    const roundRange = r.range || r?.zones?.[0]?.range || "3pt";
+    const spz = Number(r.shotsPerZone ?? r?.zones?.[0]?.attempts ?? 10);
+    const zones = (r.zones || []).map((z) => ({
+      position: z.position || z.zoneId || "center",
+      range: z.range || roundRange,
+      made: Number(z.made || 0),
+      attempts: Number(z.attempts ?? spz),
+    }));
+    return {
+      roundIndex: r.roundIndex ?? idx,
+      direction: r.direction || "static",
+      range: roundRange,
+      shotsPerZone: spz,
+      zones,
+    };
+  });
+  return clone;
+}

--- a/src/lib/sessionApi.js
+++ b/src/lib/sessionApi.js
@@ -1,0 +1,30 @@
+// src/lib/sessionApi.js
+import { db } from "./firebase";
+import {
+  collection, addDoc, doc, getDocs, query, where, orderBy, limit,
+  updateDoc, deleteDoc, startAfter
+} from "firebase/firestore";
+
+const sessionsCol = collection(db, "sessions");
+
+export async function listSessions(uid, pageSize = 10, cursor) {
+  let q = query(sessionsCol, where("userId","==",uid), orderBy("date","desc"), limit(pageSize));
+  if (cursor) q = query(sessionsCol, where("userId","==",uid), orderBy("date","desc"), startAfter(cursor), limit(pageSize));
+  const snap = await getDocs(q);
+  return { docs: snap.docs.map(d => ({ id: d.id, ...d.data() })), cursor: snap.docs.at(-1) };
+}
+
+export async function createSession(data) {
+  data.createdAt = Date.now();
+  data.updatedAt = Date.now();
+  return await addDoc(sessionsCol, data);
+}
+
+export async function updateSession(id, data) {
+  data.updatedAt = Date.now();
+  await updateDoc(doc(db, "sessions", id), data);
+}
+
+export async function deleteSession(id) {
+  await deleteDoc(doc(db, "sessions", id));
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,16 +1,88 @@
+import { useEffect, useState } from "react";
 import { useAuthStore } from "../store/useAuthStore";
+import { newSession } from "../lib/models";
+import { listSessions, createSession, updateSession, deleteSession } from "../lib/sessionApi";
+import SessionForm from "../components/SessionForm";
 
 export default function Dashboard() {
   const { user, logout } = useAuthStore();
+  const [rows, setRows] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [editing, setEditing] = useState(null); // null | {id?, ...data}
+
+  const load = async (reset=false)=>{
+    if (!user) return;
+    const res = await listSessions(user.uid, 10, reset? null : cursor);
+    setRows(reset? res.docs : [...rows, ...res.docs]);
+    setCursor(res.cursor || null);
+  };
+
+  useEffect(()=>{ load(true); }, [user]); // initial load when user is ready
+
+  const onCreateClick = ()=> setEditing(newSession(user.uid));
+  const onEditClick = (row)=> setEditing({ id: row.id, ...row });
+  const onDeleteClick = async (id)=>{ await deleteSession(id); await load(true); };
+
+  const onSave = async (data)=>{
+    if (editing.id) await updateSession(editing.id, data);
+    else await createSession(data);
+    setEditing(null);
+    await load(true);
+  };
+
   return (
-    <div className="p-6">
-      <div className="flex justify-between items-center mb-6">
+    <div className="p-6 space-y-4">
+      <div className="flex justify-between items-center">
         <h1 className="text-xl">Welcome, {user?.email}</h1>
         <button onClick={logout} className="border rounded-lg px-3 py-2">Logout</button>
       </div>
-      <div className="rounded-xl border p-6">
-        Sprint 1 ✅ — Auth working. Next: Sessions CRUD.
+
+      <div className="flex gap-2">
+        <button onClick={onCreateClick} className="bg-black text-white rounded-xl px-4 py-2">New session</button>
+        {cursor && <button onClick={()=>load()} className="border rounded-xl px-3 py-2">Load more</button>}
       </div>
+
+      <div className="overflow-x-auto border rounded-2xl">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left p-3">Date</th>
+              <th className="text-left p-3">Type</th>
+              <th className="text-left p-3">Rounds</th>
+              <th className="text-left p-3">Accuracy</th>
+              <th className="text-left p-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(r=>(
+              <tr key={r.id} className="border-t">
+                <td className="p-3">{r.date}</td>
+                <td className="p-3">{r.type}</td>
+                <td className="p-3">{r.rounds?.length ?? 0}</td>
+                <td className="p-3">{r.totals?.attempts ? Math.round((r.totals.made/r.totals.attempts)*100) : 0}%</td>
+                <td className="p-3">
+                  <button className="mr-2 underline" onClick={()=>onEditClick(r)}>Edit</button>
+                  <button className="underline" onClick={()=>onDeleteClick(r.id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+            {!rows.length && <tr><td className="p-3" colSpan={5}>No sessions yet.</td></tr>}
+          </tbody>
+        </table>
+      </div>
+
+      {editing && (
+        <div className="fixed inset-0 bg-black/40 grid place-items-center p-4">
+          <div className="bg-white rounded-2xl p-4 max-w-5xl w-full max-h-[90vh] overflow-auto">
+            <h2 className="text-lg font-semibold mb-3">{editing.id ? "Edit session" : "New session"}</h2>
+            <SessionForm
+              initial={editing}
+              onSubmit={onSave}
+              onCancel={()=>setEditing(null)}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Add 5-position model (Left Corner, Left Wing, Center, Right Wing, Right Corner)
- Round-level range (paint/midrange/3pt) and shots/round (5/10/20)
- Form clamps made ≤ attempts; attempts auto-filled per round
- Firestore CRUD + minimal security rules
- Dashboard table with Edit/Delete
- Composite index: sessions(userId ASC, date DESC)