### PR TITLE
Sprint 5.1 — Mobile-first responsiveness (Dashboard, Analytics, Forms)

### DIFF
--- a/src/components/SessionForm.jsx
+++ b/src/components/SessionForm.jsx
@@ -10,9 +10,8 @@ import {
   normalizeInitial,
 } from "../lib/models";
 
-/** map the visual order of positions based on direction */
+/** Visual order of positions based on direction */
 function orderForDirection(dir) {
-  // support both label and canonical values just in case
   const isRTL =
     dir === "R→L" ||
     dir === "R-L" ||
@@ -20,7 +19,7 @@ function orderForDirection(dir) {
     dir === "rtl";
   return isRTL
     ? ["right_corner", "right_wing", "center", "left_wing", "left_corner"]
-    : ["left_corner", "left_wing", "center", "right_wing", "right_corner"]; // static/L→R
+    : ["left_corner", "left_wing", "center", "right_wing", "right_corner"]; // static / L→R
 }
 
 export default function SessionForm({ initial, onSubmit, onCancel }) {
@@ -118,95 +117,126 @@ export default function SessionForm({ initial, onSubmit, onCancel }) {
   };
 
   return (
-    <div className="space-y-4">
-      {/* Header row */}
-      <div className="grid gap-3 sm:grid-cols-3">
-        <input
-          type="date"
-          value={model.date}
-          onChange={(e) => setField("date", e.target.value)}
-          className="border rounded-xl p-2"
-        />
-        <select
-          value={model.type}
-          onChange={(e) => setField("type", e.target.value)}
-          className="border rounded-xl p-2"
-        >
-          {TRAINING_TYPES.map((t) => (
-            <option key={t}>{t}</option>
-          ))}
-        </select>
-        <input
-          placeholder="Notes"
-          value={model.notes}
-          onChange={(e) => setField("notes", e.target.value)}
-          className="border rounded-xl p-2"
-        />
+    <div className="space-y-4 md:space-y-6">
+      {/* Header: mobile-first grid */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs md:text-sm opacity-70">Date</label>
+          <input
+            type="date"
+            value={model.date}
+            onChange={(e) => setField("date", e.target.value)}
+            className="border rounded-xl p-2 text-sm md:text-base"
+            aria-label="Session date"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs md:text-sm opacity-70">Training type</label>
+          <select
+            value={model.type}
+            onChange={(e) => setField("type", e.target.value)}
+            className="border rounded-xl p-2 text-sm md:text-base"
+            aria-label="Training type"
+          >
+            {TRAINING_TYPES.map((t) => (
+              <option key={t}>{t}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1 lg:col-span-1 sm:col-span-2">
+          <label className="text-xs md:text-sm opacity-70">Notes</label>
+          <input
+            placeholder="Optional notes"
+            value={model.notes}
+            onChange={(e) => setField("notes", e.target.value)}
+            className="border rounded-xl p-2 text-sm md:text-base"
+            aria-label="Notes"
+          />
+        </div>
       </div>
 
       {/* Rounds */}
       {model.rounds.map((r, i) => (
-        <div key={i} className="border rounded-2xl p-3 space-y-3">
-          <div className="flex flex-wrap gap-3 items-center">
-            <span className="font-medium">Round {i + 1}</span>
+        <div key={i} className="border rounded-2xl p-3 md:p-4 space-y-3 md:space-y-4">
+          {/* Round header controls: responsive grid */}
+          <div className="grid gap-2 sm:gap-3 grid-cols-2 md:grid-cols-5 items-center">
+            <div className="col-span-2 md:col-span-1 flex items-center">
+              <span className="font-medium text-sm md:text-base">Round {i + 1}</span>
+            </div>
 
             {/* Direction */}
-            <select
-              value={r.direction}
-              onChange={(e) => {
-                const v = e.target.value;
-                setModel((m) => {
-                  const rounds = [...m.rounds];
-                  rounds[i] = { ...rounds[i], direction: v };
-                  return { ...m, rounds };
-                });
-              }}
-              className="border rounded-lg p-2"
-            >
-              {DIRECTIONS.map((d) => (
-                <option key={d}>{d}</option>
-              ))}
-            </select>
+            <div className="col-span-1">
+              <label className="block text-xs opacity-70 mb-1">Direction</label>
+              <select
+                value={r.direction}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setModel((m) => {
+                    const rounds = [...m.rounds];
+                    rounds[i] = { ...rounds[i], direction: v };
+                    return { ...m, rounds };
+                  });
+                }}
+                className="w-full border rounded-lg p-2 text-sm md:text-base"
+                aria-label="Direction"
+              >
+                {DIRECTIONS.map((d) => (
+                  <option key={d}>{d}</option>
+                ))}
+              </select>
+            </div>
 
             {/* Range for ALL zones */}
-            <select
-              value={r.range}
-              onChange={(e) => onChangeRoundRange(i, e.target.value)}
-              className="border rounded-lg p-2"
-              title="Shot range for all positions in this round"
-            >
-              {RANGE_TYPES.map((rt) => (
-                <option key={rt} value={rt}>
-                  {rt}
-                </option>
-              ))}
-            </select>
+            <div className="col-span-1">
+              <label className="block text-xs opacity-70 mb-1">Range</label>
+              <select
+                value={r.range}
+                onChange={(e) => onChangeRoundRange(i, e.target.value)}
+                className="w-full border rounded-lg p-2 text-sm md:text-base"
+                title="Shot range for all positions in this round"
+                aria-label="Range"
+              >
+                {RANGE_TYPES.map((rt) => (
+                  <option key={rt} value={rt}>
+                    {rt}
+                  </option>
+                ))}
+              </select>
+            </div>
 
             {/* shots/round (attempts per zone) */}
-            <select
-              value={r.shotsPerZone ?? 10}
-              onChange={(e) => onChangeShotsPerZone(i, e.target.value)}
-              className="border rounded-lg p-2"
-              title="Attempts per position for this round"
-            >
-              {[5, 10, 20].map((n) => (
-                <option key={n} value={n}>
-                  {n} shots/round
-                </option>
-              ))}
-            </select>
+            <div className="col-span-1">
+              <label className="block text-xs opacity-70 mb-1">Shots per zone</label>
+              <select
+                value={r.shotsPerZone ?? 10}
+                onChange={(e) => onChangeShotsPerZone(i, e.target.value)}
+                className="w-full border rounded-lg p-2 text-sm md:text-base"
+                title="Attempts per position for this round"
+                aria-label="Shots per zone"
+              >
+                {[5, 10, 20].map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </div>
 
-            <button
-              type="button"
-              onClick={() => removeRound(i)}
-              className="ml-auto text-sm border rounded-lg px-2 py-1"
-            >
-              Remove
-            </button>
+            <div className="col-span-1 md:col-span-1 flex justify-end items-end">
+              <button
+                type="button"
+                onClick={() => removeRound(i)}
+                className="text-sm border rounded-lg px-2 py-2 hover:bg-gray-50 w-full md:w-auto"
+              >
+                Remove
+              </button>
+            </div>
           </div>
 
-          {/* Zone cards: visual order depends on direction */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+          {/* Zone cards: 1/2/3 columns */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 md:gap-3">
             {(orderForDirection(r.direction) || ZONE_POSITIONS).map((pos) => {
               const z =
                 r.zones.find((x) => x.position === pos) || {
@@ -217,34 +247,47 @@ export default function SessionForm({ initial, onSubmit, onCancel }) {
                 };
               const attempts = Number(r.shotsPerZone ?? z.attempts ?? 0);
               return (
-                <div key={pos} className="border rounded-xl p-3 space-y-2">
-                  <div className="text-sm font-medium">
+                <div key={pos} className="border rounded-xl p-3 md:p-4 space-y-2">
+                  <div className="text-sm md:text-base font-medium">
                     {pretty[pos]}{" "}
-                    <span className="text-xs text-gray-500">
+                    <span className="text-xs md:text-sm text-gray-500">
                       ({r.range} • {attempts})
                     </span>
                   </div>
-                  <div className="flex gap-2">
+
+                  {/* Inputs row as grid for stable widths */}
+                  <div className="grid grid-cols-2 gap-2">
                     {/* Made (editable) */}
-                    <input
-                      type="number"
-                      min="0"
-                      className="w-1/2 border rounded p-2"
-                      value={z.made ?? 0}
-                      onChange={(e) => {
-                        const n = Number(e.target.value);
-                        const clamped = Math.min(Math.max(0, n), attempts);
-                        setZone(i, pos, { made: clamped });
-                      }}
-                    />
-                    {/* Attempts (read-only) */}
-                    <input
-                      type="number"
-                      className="w-1/2 border rounded p-2 bg-gray-50"
-                      value={attempts}
-                      readOnly
-                      tabIndex={-1}
-                    />
+                    <div className="flex flex-col gap-1">
+                      <label className="text-xs opacity-70">Made</label>
+                      <input
+                        type="number"
+                        min="0"
+                        max={attempts}
+                        inputMode="numeric"
+                        className="w-full border rounded p-2 text-sm md:text-base"
+                        value={z.made ?? 0}
+                        onChange={(e) => {
+                          const n = Number(e.target.value);
+                          const clamped = Math.min(Math.max(0, n), attempts);
+                          setZone(i, pos, { made: clamped });
+                        }}
+                        aria-label={`${pretty[pos]} made`}
+                      />
+                    </div>
+
+                    {/* Attempts (read-only, reflects shotsPerZone) */}
+                    <div className="flex flex-col gap-1">
+                      <label className="text-xs opacity-70">Attempts</label>
+                      <input
+                        type="number"
+                        className="w-full border rounded p-2 bg-gray-50 text-sm md:text-base"
+                        value={attempts}
+                        readOnly
+                        tabIndex={-1}
+                        aria-label={`${pretty[pos]} attempts`}
+                      />
+                    </div>
                   </div>
                 </div>
               );
@@ -253,15 +296,28 @@ export default function SessionForm({ initial, onSubmit, onCancel }) {
         </div>
       ))}
 
-      <div className="flex gap-2">
-        <button type="button" onClick={addRound} className="border rounded-xl px-3 py-2">
+      {/* Actions */}
+      <div className="flex flex-wrap gap-2 justify-end">
+        <button
+          type="button"
+          onClick={addRound}
+          className="border rounded-xl px-3 py-2 text-sm md:text-base"
+        >
           + Add round
         </button>
         <div className="ml-auto flex gap-2">
-          <button type="button" onClick={onCancel} className="border rounded-xl px-3 py-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="border rounded-xl px-3 py-2 text-sm md:text-base"
+          >
             Cancel
           </button>
-          <button type="button" onClick={submit} className="bg-black text-white rounded-xl px-4 py-2">
+          <button
+            type="button"
+            onClick={submit}
+            className="bg-black text-white rounded-xl px-4 py-2 text-sm md:text-base"
+          >
             Save session
           </button>
         </div>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -11,8 +11,8 @@ import {
 import SessionForm from "../components/SessionForm";
 
 // Analytics bits
-import HeatmapCourt from "../components/HeatmapCourt";               // blocks view
-import HeatmapCourtImage from "../components/HeatmapCourtImage";     // court.png overlay
+import HeatmapCourt from "../components/HeatmapCourt";               // blocks list (left sidebar)
+import HeatmapCourtImage from "../components/HeatmapCourtImage";     // court.png overlay (responsive)
 import AccuracyTrend from "../components/charts/AccuracyTrend";
 import AttemptsVsMadeByType from "../components/charts/AttemptsVsMadeByType";
 import AnalyticsFilters from "../components/AnalyticsFilters";
@@ -25,7 +25,7 @@ import {
   computeKpis,
 } from "../lib/analytics";
 
-// DEV: seeding helper (dev-only button)
+// DEV only helper
 import { seedSessions } from "../dev/seedSessions";
 
 export default function Dashboard() {
@@ -35,7 +35,7 @@ export default function Dashboard() {
   const [rows, setRows] = useState([]);
   const [cursor, setCursor] = useState(null);
 
-  // editor
+  // editor modal
   const [editing, setEditing] = useState(null); // null | {id?, ...data}
 
   // tabs
@@ -108,9 +108,7 @@ export default function Dashboard() {
 
   const onSave = async (data) => {
     try {
-      // always stamp ownership on the payload
-      const payload = { ...data, userId: user.uid };
-
+      const payload = { ...data, userId: user.uid }; // ownership guard
       if (editing?.id) {
         await updateSession(editing.id, payload);
       } else {
@@ -146,39 +144,35 @@ export default function Dashboard() {
   );
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-4 md:p-6 space-y-4 md:space-y-6">
       {/* Header */}
       <div className="flex flex-wrap gap-3 justify-between items-center">
-        <h1 className="text-xl">Welcome, {user?.email}</h1>
+        <h1 className="text-lg md:text-xl font-medium">
+          Welcome, {user?.email}
+        </h1>
         <div className="flex items-center gap-2">
-          {/* DEV-ONLY seed button */}
           {import.meta.env.DEV && (
             <button
-              className="border rounded-lg px-3 py-2"
+              className="border rounded-lg px-3 py-2 text-sm md:text-base"
               onClick={async () => {
-                const n = 25; // change as needed
-                try {
-                  await seedSessions(user.uid, n);
-                  await load(true);
-                  alert(`Seeded ${n} sessions for ${user.email}`);
-                } catch (e) {
-                  console.error("Seeding failed:", e);
-                  alert(e?.message || "Seeding failed");
-                }
+                const n = 25;
+                await seedSessions(user.uid, n);
+                await load(true);
+                alert(`Seeded ${n} sessions for ${user.email}`);
               }}
               title="Create random sessions for testing pagination"
             >
               Seed 25 sessions
             </button>
           )}
-          <button onClick={logout} className="border rounded-lg px-3 py-2">
+          <button onClick={logout} className="border rounded-lg px-3 py-2 text-sm md:text-base">
             Logout
           </button>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-2 border-b">
+      <div className="flex gap-2 border-b overflow-x-auto">
         <TabButton active={tab === "log"} onClick={() => setTab("log")}>
           Log
         </TabButton>
@@ -213,8 +207,8 @@ export default function Dashboard() {
       {/* Editor modal */}
       {editing && (
         <div className="fixed inset-0 bg-black/40 grid place-items-center p-4">
-          <div className="bg-white rounded-2xl p-4 max-w-5xl w-full max-h-[90vh] overflow-auto">
-            <h2 className="text-lg font-semibold mb-3">
+          <div className="bg-white rounded-2xl p-4 md:p-6 max-w-5xl w-full max-h-[90vh] overflow-auto">
+            <h2 className="text-lg md:text-xl font-semibold mb-3">
               {editing.id ? "Edit session" : "New session"}
             </h2>
             <SessionForm initial={editing} onSubmit={onSave} onCancel={() => setEditing(null)} />
@@ -288,8 +282,7 @@ function LogSection({
   const end = start + pageSize;
   const paged = sorted.slice(start, end);
 
-  // 4) CSV export of filtered+sorted rows (not just current page)
-  // 4) CSV export of filtered+sorted rows (not just current page)
+  // 4) CSV export of filtered+sorted rows (not just current page) — includes "Made"
   const exportCsv = () => {
     const headers = ["Date", "Type", "Rounds", "Accuracy", "Attempts", "Made", "Notes"];
     const toRow = (s) => {
@@ -303,7 +296,7 @@ function LogSection({
         s.rounds?.length ?? 0,
         `${acc}%`,
         attempts,
-        made,              // <-- NEW COLUMN
+        made,
         `"${notes}"`,
       ].join(",");
     };
@@ -342,18 +335,18 @@ function LogSection({
   );
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3 md:space-y-4">
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-2">
-        <button onClick={onCreate} className="bg-black text-white rounded-xl px-4 py-2">
+        <button onClick={onCreate} className="bg-black text-white rounded-xl px-4 py-2 text-sm md:text-base">
           New session
         </button>
 
-        {/* Clear log (danger) */}
+        {/* Clear log */}
         <button
           onClick={onClearAll}
           disabled={!rows.length || clearing}
-          className={`rounded-xl px-3 py-2 border ${
+          className={`rounded-xl px-3 py-2 border text-sm md:text-base ${
             clearing ? "opacity-60 cursor-not-allowed" : "hover:bg-red-50"
           } text-red-600`}
           title="Delete ALL sessions for your account"
@@ -368,7 +361,7 @@ function LogSection({
             setTypeFilter(e.target.value);
             setPage(0);
           }}
-          className="border rounded-lg p-2"
+          className="border rounded-lg p-2 text-sm md:text-base"
           title="Filter by training type"
         >
           <option value="all">All types</option>
@@ -386,7 +379,7 @@ function LogSection({
             setFrom(e.target.value);
             setPage(0);
           }}
-          className="border rounded-lg p-2"
+          className="border rounded-lg p-2 text-sm md:text-base"
           title="From"
         />
         <input
@@ -396,7 +389,7 @@ function LogSection({
             setTo(e.target.value);
             setPage(0);
           }}
-          className="border rounded-lg p-2"
+          className="border rounded-lg p-2 text-sm md:text-base"
           title="To"
         />
 
@@ -405,7 +398,7 @@ function LogSection({
           <button
             onClick={exportCsv}
             disabled={!sorted.length}
-            className="border rounded-lg px-3 py-2 text-sm hover:bg-gray-100 disabled:opacity-40"
+            className="border rounded-lg px-3 py-2 text-sm md:text-base hover:bg-gray-100 disabled:opacity-40"
             title="Export filtered rows as CSV"
           >
             Export CSV
@@ -418,7 +411,7 @@ function LogSection({
               setPageSize(Number(e.target.value));
               setPage(0);
             }}
-            className="border rounded-lg p-2"
+            className="border rounded-lg p-2 text-sm md:text-base"
           >
             {[10, 20, 50].map((n) => (
               <option key={n} value={n}>
@@ -428,7 +421,7 @@ function LogSection({
           </select>
 
           {cursor && (
-            <button onClick={onLoadMore} className="border rounded-xl px-3 py-2">
+            <button onClick={onLoadMore} className="border rounded-xl px-3 py-2 text-sm md:text-base">
               Load more
             </button>
           )}
@@ -437,7 +430,7 @@ function LogSection({
 
       {/* Table */}
       <div className="overflow-x-auto border rounded-2xl">
-        <table className="w-full text-sm">
+        <table className="w-full text-sm md:text-[15px]">
           <thead className="bg-gray-50">
             <tr>
               <Th k="date">Date</Th>
@@ -517,24 +510,27 @@ function LogSection({
 /* ---------- Analytics UI ---------- */
 function AnalyticsSection({ filters, setFilters, kpis, byPos, trend, byType }) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 md:space-y-6">
       <AnalyticsFilters value={filters} onChange={setFilters} />
       <KpiTiles kpis={kpis} windowDays={filters.windowDays || 7} />
 
-      {/* Heatmaps side-by-side (stacked on mobile) */}
-      <div className="grid grid-cols-1 lg:grid-cols-[380px,1fr] gap-6 items-start">
+      {/* Heatmaps side-by-side on large screens; stacked on mobile */}
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(280px,380px),1fr] gap-4 md:gap-6 items-start">
         <div className="lg:sticky lg:top-4">
           <HeatmapCourt data={byPos} layout="stack" />
         </div>
-        <HeatmapCourtImage
-          data={byPos}
-          src="/court.png"
-          range={filters.range || "3pt"}
-          direction={filters.direction}
-          width={600}
-          height={567}
-          flip={true} // offense view
-        />
+        <div className="w-full">
+          <HeatmapCourtImage
+            data={byPos}
+            src="/court.png"
+            range={filters.range || "3pt"}
+            direction={filters.direction}
+            width={600}
+            height={567}
+            flip={true} // offense view
+            className="w-full max-w-[620px] mx-auto"
+          />
+        </div>
       </div>
 
       <AccuracyTrend data={trend} />


### PR DESCRIPTION
Implements mobile-first layouts using Tailwind breakpoints (sm, md, lg).

**Dashboard**

- Toolbars wrap on small screens; CSV/filters stay usable.
- Table in a scroll container on mobile; sticky footer pagination.
- Analytics layout stacks (Zones list + Court image) on small screens.

**Analytics**

- Court heatmap scales with container; mobile shows % only inside boxes for readability.
- Flip (offense view) kept.
- 

**SessionForm**

- Header fields in a compact grid on phones, expand on larger screens.
- Rounds controls in responsive grid; zone cards 1/2/3 columns.
- Attempts per zone mirrored from “shots per zone”; clamp made ≤ attempts.
- Typography & spacing scale consistently (p-4 md:p-6, text-sm md:text-base).

**Checklist**

-  ≤400px viewport: no horizontal scroll on Dashboard/Analytics/SessionForm.
-  Heatmap labels legible on mobile (percent only).
-  Modals fit within 90vh, scroll internally.
-  No console errors/warnings.
-  Existing data and routes unaffected.
- Screens to sanity-check after merge
- /dashboard (both tabs), open “New session”.
- Heatmap with each range (paint/mid/3pt), flip on.
- Table CSV export still works.