### PR TITLE
Sprint 5.4 — Loading spinners & skeleton screens (no layout shift)

### DIFF
--- a/src/components/ui/Skeleton.jsx
+++ b/src/components/ui/Skeleton.jsx
@@ -1,0 +1,26 @@
+// src/components/ui/Skeleton.jsx
+export function Skeleton({ className = "" }) {
+  return (
+    <div
+      className={`relative overflow-hidden bg-gray-200 rounded ${className}`}
+      aria-hidden="true"
+    >
+      <div className="absolute inset-0 -translate-x-full animate-[shimmer_1.2s_infinite] bg-gradient-to-r from-transparent via-white/50 to-transparent" />
+      <style>{`
+        @keyframes shimmer {
+          100% { transform: translateX(100%); }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export function SkeletonText({ lines = 1 }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton key={i} className="h-3" />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/Spinner.jsx
+++ b/src/components/ui/Spinner.jsx
@@ -1,0 +1,28 @@
+// src/components/ui/Spinner.jsx
+export default function Spinner({ size = 16, className = "" }) {
+  const s = `${size}px`;
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      width={s}
+      height={s}
+      viewBox="0 0 24 24"
+      aria-label="Loading"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+        fill="none"
+      />
+      <path
+        className="opacity-90"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}

--- a/src/lib/devDelay.js
+++ b/src/lib/devDelay.js
@@ -1,0 +1,7 @@
+// src/lib/devDelay.js
+export const devDelay = async (ms = 1200) => {
+  // Only delay in dev AND when ?slow is present
+  if (import.meta.env.DEV && new URLSearchParams(location.search).has("slow")) {
+    await new Promise((r) => setTimeout(r, ms));
+  }
+};


### PR DESCRIPTION
Adds Spinner and Skeleton components.

**Dashboard**

- First-load shows table skeleton rows; “Load more” removed, list auto-fetches all pages.
- Export CSV shows inline spinner.
- Analytics: skeleton tiles for KPIs, skeleton blocks for court heatmap & charts with fixed aspect/height → no layout jump.

**Dev UX**

- Simulate slow toggle (dev-only) flips ?slow without reload; devDelay honors it.
- Keeps toast notifications from 5.2 and mobile-first layout from 5.1.

**QA checklist**

-  With ?slow, first load shows skeleton rows; header doesn’t shift.
-  Heatmap/card/chart skeletons render with fixed sizes; no CLS spikes.
-  Export CSV shows spinner; success toast appears.
-  Toggle Simulate slow ON/OFF updates URL and delays.
-  All sessions load automatically (no “Load more”).
-  No console errors.